### PR TITLE
Fix broken GIF

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img align="right" width="200" height="200" src="assets/2020-mood.gif">
+<img align="right" width="200" height="200" src="https://github.com/loong/loong/raw/master/assets/2020-mood.gif">
 
 # I turn beer into code
 


### PR DESCRIPTION
Use URL instead of relative path to load mood GIF to fix the broken GIF when visiting the main profile page.

<img width="1283" alt="Screenshot 2020-08-01 at 14 07 43" src="https://user-images.githubusercontent.com/1732217/89095425-79fe0300-d400-11ea-9703-ba0605bf553f.png">
